### PR TITLE
Use `showBaseUrl` from `servant-client-core`

### DIFF
--- a/src/Servant/Client/JS.hs
+++ b/src/Servant/Client/JS.hs
@@ -166,15 +166,11 @@ abort (AbortController o) = do
 
 
 getFetchArgs :: ClientEnv -> Request -> Maybe AbortController -> JSM [JSVal]
-getFetchArgs (ClientEnv (BaseUrl urlScheme host port basePath))
+getFetchArgs (ClientEnv baseUrl)
              (Request reqPath reqQs reqBody reqAccept reqHdrs _reqVer reqMethod)
              abortController = do
   self <- jsg "self"
-  let schemeStr :: Text
-      schemeStr = case urlScheme of
-                    Http  -> "http://"
-                    Https -> "https://"
-  url <- toJSVal $ schemeStr <> pack host <> ":" <> pack (show port) <> pack basePath
+  url <- toJSVal $ pack (showBaseUrl baseUrl)
                              <> decodeUtf8 (BL.toStrict (toLazyByteString reqPath))
                              <> (if Prelude.null reqQs then "" else "?" ) <> (intercalate "&"
                                         $ (\(k,v) -> decodeUtf8 k <> "="

--- a/src/Servant/Client/JS.hs
+++ b/src/Servant/Client/JS.hs
@@ -170,7 +170,7 @@ getFetchArgs (ClientEnv baseUrl)
              (Request reqPath reqQs reqBody reqAccept reqHdrs _reqVer reqMethod)
              abortController = do
   self <- jsg "self"
-  url <- toJSVal $ pack (showBaseUrl baseUrl)
+  url <- toJSVal $ (if null (baseUrlHost baseUrl) then "" else pack (showBaseUrl baseUrl))
                              <> decodeUtf8 (BL.toStrict (toLazyByteString reqPath))
                              <> (if Prelude.null reqQs then "" else "?" ) <> (intercalate "&"
                                         $ (\(k,v) -> decodeUtf8 k <> "="


### PR DESCRIPTION
This is better in at least one way: for `BaseUrl Http "a.com" 1 "b"` it produces `"http://a.com:1/b"` instead of `"http://a.com:1b"`.